### PR TITLE
Update sia_storage_ffi to v0.8.0

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -116,7 +116,7 @@ jobs:
           import SiaStorageSDK
           import Foundation
 
-          let _ = try Builder(indexerUrl: "https://sia.storage", appMeta: AppMeta(id: Data(repeating: 0x01, count: 32), name: "smoke test", description: "smoke test", serviceUrl: "https://example.com", logoUrl: nil, callbackUrl: nil))
+          let _ = try Builder(indexerUrl: "https://sia.storage", appMeta: AppMetadata(id: Data(repeating: 0x01, count: 32), name: "smoke test", description: "smoke test", serviceUrl: "https://example.com", logoUrl: nil, callbackUrl: nil))
           print("consumer smoke build ok")
           EOF
           SIA_STORAGE_SDK_USE_LOCAL_XCFRAMEWORK=1 swift build
@@ -283,7 +283,7 @@ jobs:
           import SiaStorageSDK
           import Foundation
 
-          let _ = try Builder(indexerUrl: "https://sia.storage", appMeta: AppMeta(id: Data(repeating: 0x01, count: 32), name: "smoke test", description: "smoke test", serviceUrl: "https://example.com", logoUrl: nil, callbackUrl: nil))
+          let _ = try Builder(indexerUrl: "https://sia.storage", appMeta: AppMetadata(id: Data(repeating: 0x01, count: 32), name: "smoke test", description: "smoke test", serviceUrl: "https://example.com", logoUrl: nil, callbackUrl: nil))
           print("release smoke build ok")
           EOF
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "sia_storage_sdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "sia_storage_ffi",
  "uniffi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,7 +2028,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sia_core"
 version = "0.3.1"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=08c22f8ce3a88b31e07675b093500062a093ba8e#08c22f8ce3a88b31e07675b093500062a093ba8e"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=a6994c84adf27c0de14aaedce2d69e6056475930#a6994c84adf27c0de14aaedce2d69e6056475930"
 dependencies = [
  "base64",
  "bip39",
@@ -2055,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "sia_core_derive"
 version = "0.1.0"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=08c22f8ce3a88b31e07675b093500062a093ba8e#08c22f8ce3a88b31e07675b093500062a093ba8e"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=a6994c84adf27c0de14aaedce2d69e6056475930#a6994c84adf27c0de14aaedce2d69e6056475930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "sia_mux"
 version = "0.1.0"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=08c22f8ce3a88b31e07675b093500062a093ba8e#08c22f8ce3a88b31e07675b093500062a093ba8e"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=a6994c84adf27c0de14aaedce2d69e6056475930#a6994c84adf27c0de14aaedce2d69e6056475930"
 dependencies = [
  "blake2b_simd",
  "bytes",
@@ -2080,8 +2080,8 @@ dependencies = [
 
 [[package]]
 name = "sia_storage"
-version = "0.7.0"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=08c22f8ce3a88b31e07675b093500062a093ba8e#08c22f8ce3a88b31e07675b093500062a093ba8e"
+version = "0.8.0"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=a6994c84adf27c0de14aaedce2d69e6056475930#a6994c84adf27c0de14aaedce2d69e6056475930"
 dependencies = [
  "base64",
  "blake2",
@@ -2121,8 +2121,8 @@ dependencies = [
 
 [[package]]
 name = "sia_storage_ffi"
-version = "0.7.0"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=08c22f8ce3a88b31e07675b093500062a093ba8e#08c22f8ce3a88b31e07675b093500062a093ba8e"
+version = "0.8.0"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=a6994c84adf27c0de14aaedce2d69e6056475930#a6994c84adf27c0de14aaedce2d69e6056475930"
 dependencies = [
  "async-trait",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "sia_storage_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-sia_storage_ffi = { git = "https://github.com/SiaFoundation/sia-sdk-rs.git", rev = "08c22f8ce3a88b31e07675b093500062a093ba8e" }
+sia_storage_ffi = { git = "https://github.com/SiaFoundation/sia-sdk-rs.git", rev = "a6994c84adf27c0de14aaedce2d69e6056475930" }
 uniffi = { version = "=0.31.1", features = ["cli", "tokio"] }
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sia_storage_sdk"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 repository = "https://github.com/SiaFoundation/sia-storage-sdk"
 license = "MIT"

--- a/examples/kotlin/src/main/kotlin/Example.kt
+++ b/examples/kotlin/src/main/kotlin/Example.kt
@@ -26,7 +26,7 @@ fun main() = runBlocking {
 
     val appId = ByteArray(32) { 0x01 }
 
-    val builder = Builder("https://sia.storage", AppMeta(
+    val builder = Builder("https://sia.storage", AppMetadata(
         id = appId,
         name = "kotlin example",
         description = "an example app",

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -6,7 +6,7 @@ from io import BytesIO
 
 from sia_storage import (
     generate_recovery_phrase,
-    AppMeta,
+    AppMetadata,
     Builder,
     PinnedObject,
     UploadOptions,
@@ -52,7 +52,7 @@ async def main():
 
     builder = Builder(
         "https://sia.storage",
-        AppMeta(
+        AppMetadata(
             id=app_id,
             name="python example",
             description="an example app",

--- a/examples/swift/Sources/main.swift
+++ b/examples/swift/Sources/main.swift
@@ -39,7 +39,7 @@ struct SiaStorageSDKExample {
 
         let appId = Data(repeating: 0x01, count: 32)
         do {
-            let builder = try await Builder(indexerUrl: "https://sia.storage", appMeta: AppMeta(
+            let builder = try await Builder(indexerUrl: "https://sia.storage", appMeta: AppMetadata(
                 id: appId,
                 name: "swift example",
                 description: "an example app",

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -30,7 +30,7 @@ fun main() = runBlocking {
 
     val appId = ByteArray(32) { 0x01 }
 
-    val builder = Builder("https://sia.storage", AppMeta(
+    val builder = Builder("https://sia.storage", AppMetadata(
         id = appId,
         name = "My App",
         description = "App description",

--- a/python/README.md
+++ b/python/README.md
@@ -22,7 +22,7 @@ from io import BytesIO
 
 from sia_storage import (
     generate_recovery_phrase,
-    AppMeta,
+    AppMetadata,
     Builder,
     DownloadOptions,
     PinnedObject,
@@ -35,7 +35,7 @@ async def main():
 
     builder = Builder(
         "https://sia.storage",
-        AppMeta(
+        AppMetadata(
             id=app_id,
             name="My App",
             description="App description",

--- a/python/sia_storage/__init__.py
+++ b/python/sia_storage/__init__.py
@@ -12,7 +12,7 @@ from sia_storage.sia_storage.sia_storage_ffi import (
     # Records
     Account,
     App,
-    AppMeta,
+    AppMetadata,
     Host,
     NetAddress,
     ObjectEvent,
@@ -73,7 +73,7 @@ __all__ = [
     # Records
     "Account",
     "App",
-    "AppMeta",
+    "AppMetadata",
     "Host",
     "NetAddress",
     "ObjectEvent",

--- a/python/sia_storage/wrappers.py
+++ b/python/sia_storage/wrappers.py
@@ -14,7 +14,7 @@ from typing import Any, BinaryIO, Callable, Optional, Union
 
 from .sia_storage.sia_storage_ffi import (
     AppKey,
-    AppMeta,
+    AppMetadata,
     Builder as _Builder,
     Download as _Download,
     DownloadOptions,
@@ -74,7 +74,7 @@ class Builder(_Builder):
     connection.
     """
 
-    def __init__(self, indexer_url: str, app_meta: AppMeta):
+    def __init__(self, indexer_url: str, app_meta: AppMetadata):
         try:
             uniffi_set_event_loop(asyncio.get_running_loop())
         except RuntimeError:

--- a/swift/README.md
+++ b/swift/README.md
@@ -48,7 +48,7 @@ import SiaStorageSDK
 setLogger(logger: MyLogger(), level: "debug")
 
 // Create a builder and connect
-let builder = try await Builder(indexerUrl: "https://sia.storage", appMeta: AppMeta(
+let builder = try await Builder(indexerUrl: "https://sia.storage", appMeta: AppMetadata(
     id: appId,
     name: "My App",
     description: "App description",

--- a/swift/Sources/SiaStorageSDK/SiaStorageSDK.swift
+++ b/swift/Sources/SiaStorageSDK/SiaStorageSDK.swift
@@ -933,12 +933,12 @@ open class Builder: BuilderProtocol, @unchecked Sendable {
      * to connect using an existing app key, or [Builder::request_connection]
      * to request a new connection.
      */
-public convenience init(indexerUrl: String, appMeta: AppMeta)throws  {
+public convenience init(indexerUrl: String, appMeta: AppMetadata)throws  {
     let handle =
         try rustCallWithError(FfiConverterTypeBuilderError_lift) {
     uniffi_sia_storage_ffi_fn_constructor_builder_new(
         FfiConverterString.lower(indexerUrl),
-        FfiConverterTypeAppMeta_lower(appMeta),$0
+        FfiConverterTypeAppMetadata_lower(appMeta),$0
     )
 }
     self.init(unsafeFromHandle: handle)
@@ -1597,16 +1597,22 @@ public func FfiConverterTypeLogger_lower(_ value: Logger) -> UInt64 {
 public protocol PackedUploadProtocol: AnyObject, Sendable {
     
     /**
-     * Adds a new object to the upload. The data will be read until EOF and packed into
-     * the upload. The resulting object will contain the metadata needed to download the object. The caller
-     * must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
+     * Adds a new object to the upload. The data is read until EOF and packed into
+     * the current slab. Returns the number of bytes consumed; call
+     * [finalize](Self::finalize) once all objects have been added to get the
+     * resulting objects.
+     *
+     * If the reader errors part-way, it's safe to continue calling
+     * [add](Self::add); no object is registered for the failed call. Or call
+     * [finalize](Self::finalize) to collect the objects added so far.
      */
     func add(reader: Reader) async throws  -> UInt64
     
     /**
-     * Cancels the upload. This will immediately cancel the upload and return.
+     * Cancels the upload. This will immediately cancel any in-progress [add](Self::add) or [finalize](Self::finalize) operations and prevent
+     * any new ones from starting. Any in-flight operations will return an error once cancelled.
      */
-    func cancel() async throws 
+    func cancel() 
     
     /**
      * Finalizes the upload and returns the resulting objects. This will wait for all readers
@@ -1694,9 +1700,14 @@ open class PackedUpload: PackedUploadProtocol, @unchecked Sendable {
 
     
     /**
-     * Adds a new object to the upload. The data will be read until EOF and packed into
-     * the upload. The resulting object will contain the metadata needed to download the object. The caller
-     * must call [finalize](Self::finalize) to get the resulting objects after all objects have been added.
+     * Adds a new object to the upload. The data is read until EOF and packed into
+     * the current slab. Returns the number of bytes consumed; call
+     * [finalize](Self::finalize) once all objects have been added to get the
+     * resulting objects.
+     *
+     * If the reader errors part-way, it's safe to continue calling
+     * [add](Self::add); no object is registered for the failed call. Or call
+     * [finalize](Self::finalize) to collect the objects added so far.
      */
 open func add(reader: Reader)async throws  -> UInt64  {
     return
@@ -1716,23 +1727,14 @@ open func add(reader: Reader)async throws  -> UInt64  {
 }
     
     /**
-     * Cancels the upload. This will immediately cancel the upload and return.
+     * Cancels the upload. This will immediately cancel any in-progress [add](Self::add) or [finalize](Self::finalize) operations and prevent
+     * any new ones from starting. Any in-flight operations will return an error once cancelled.
      */
-open func cancel()async throws   {
-    return
-        try  await uniffiRustCallAsync(
-            rustFutureFunc: {
-                uniffi_sia_storage_ffi_fn_method_packedupload_cancel(
-                    self.uniffiCloneHandle()
-                    
-                )
-            },
-            pollFunc: ffi_sia_storage_ffi_rust_future_poll_void,
-            completeFunc: ffi_sia_storage_ffi_rust_future_complete_void,
-            freeFunc: ffi_sia_storage_ffi_rust_future_free_void,
-            liftFunc: { $0 },
-            errorHandler: FfiConverterTypeUploadError_lift
-        )
+open func cancel()  {try! rustCall() {
+    uniffi_sia_storage_ffi_fn_method_packedupload_cancel(
+            self.uniffiCloneHandle(),$0
+    )
+}
 }
     
     /**
@@ -3306,7 +3308,7 @@ public func FfiConverterTypeApp_lower(_ value: App) -> RustBuffer {
 /**
  * Metadata about an application connecting to the indexer.
  */
-public struct AppMeta: Equatable, Hashable {
+public struct AppMetadata: Equatable, Hashable {
     public var id: Data
     public var name: String
     public var description: String
@@ -3331,16 +3333,16 @@ public struct AppMeta: Equatable, Hashable {
 }
 
 #if compiler(>=6)
-extension AppMeta: Sendable {}
+extension AppMetadata: Sendable {}
 #endif
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public struct FfiConverterTypeAppMeta: FfiConverterRustBuffer {
-    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppMeta {
+public struct FfiConverterTypeAppMetadata: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AppMetadata {
         return
-            try AppMeta(
+            try AppMetadata(
                 id: FfiConverterData.read(from: &buf), 
                 name: FfiConverterString.read(from: &buf), 
                 description: FfiConverterString.read(from: &buf), 
@@ -3350,7 +3352,7 @@ public struct FfiConverterTypeAppMeta: FfiConverterRustBuffer {
         )
     }
 
-    public static func write(_ value: AppMeta, into buf: inout [UInt8]) {
+    public static func write(_ value: AppMetadata, into buf: inout [UInt8]) {
         FfiConverterData.write(value.id, into: &buf)
         FfiConverterString.write(value.name, into: &buf)
         FfiConverterString.write(value.description, into: &buf)
@@ -3364,15 +3366,15 @@ public struct FfiConverterTypeAppMeta: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeAppMeta_lift(_ buf: RustBuffer) throws -> AppMeta {
-    return try FfiConverterTypeAppMeta.lift(buf)
+public func FfiConverterTypeAppMetadata_lift(_ buf: RustBuffer) throws -> AppMetadata {
+    return try FfiConverterTypeAppMetadata.lift(buf)
 }
 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
-public func FfiConverterTypeAppMeta_lower(_ value: AppMeta) -> RustBuffer {
-    return FfiConverterTypeAppMeta.lower(value)
+public func FfiConverterTypeAppMetadata_lower(_ value: AppMetadata) -> RustBuffer {
+    return FfiConverterTypeAppMetadata.lower(value)
 }
 
 
@@ -5570,10 +5572,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_sia_storage_ffi_checksum_method_download_read() != 37314) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_sia_storage_ffi_checksum_method_packedupload_add() != 21090) {
+    if (uniffi_sia_storage_ffi_checksum_method_packedupload_add() != 51351) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_sia_storage_ffi_checksum_method_packedupload_cancel() != 48516) {
+    if (uniffi_sia_storage_ffi_checksum_method_packedupload_cancel() != 64519) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_sia_storage_ffi_checksum_method_packedupload_finalize() != 48196) {
@@ -5714,7 +5716,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_sia_storage_ffi_checksum_constructor_appkey_new() != 6640) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_sia_storage_ffi_checksum_constructor_builder_new() != 20006) {
+    if (uniffi_sia_storage_ffi_checksum_constructor_builder_new() != 24760) {
         return InitializationResult.apiChecksumMismatch
     }
 


### PR DESCRIPTION
## Breaking Changes

### Rename `AppMeta` to `AppMetadata`

The uniffi struct accepted by `Builder::new` is now named `AppMetadata`, matching the Rust SDK and the WASM binding.

### Rename `slab_size` to `optimal_data_size` where it refers to the data-only portion

Methods and fields that previously returned or stored `data_shards * SECTOR_SIZE` (the packing period for `PackedUpload`) are now named `optimal_data_size` to distinguish them from the true encoded slab size (`total_shards * SECTOR_SIZE`, which remains `slab_size`). Affects `PackedUpload::slab_size()` (Rust, FFI, NAPI) and the `slabSize` JS getter (now `optimalDataSize`).

`UploadOptions::slab_size()`, `UploadOptions::optimal_data_size()`, `PackedUpload::optimal_data_size()`, and `PackedUpload::slabs()` now return `usize` instead of `u64`.

### Simplify `PackedUpload` binding internals

Replaced the per-upload mpsc actor with a mutex and a cancellation token. Errors from `add` and `finalize` now propagate directly instead of through a oneshot that could swallow them, and no background task is kept per upload.

`cancel` is now sync (`fn cancel(&self)`) on the FFI and NAPI bindings, dropping the `async` and `Result` return — flipping a token and aborting in-flight tasks is fast and cannot fail. WASM was already sync.

## Features

- `upload_packed` now returns a `Result` and will error if invalid options are passed to it.

### `PackedUpload` stays usable after a reader error

If the reader passed to `add` errored mid-stream, bytes it had already buffered were silently attributed to the next object, corrupting it. Partial reads now become dead padding in the slab and subsequent objects stay aligned.

## Fixes

- Rename download close function