### PR TITLE
chore: update sia_storage_ffi to 0.10.0

### DIFF
--- a/.github/workflows/check-sdk-update.yml
+++ b/.github/workflows/check-sdk-update.yml
@@ -135,6 +135,7 @@ jobs:
           # The new rev can require newer transitive deps than Cargo.lock pins;
           # fetch alone may not unlock them, so re-resolve the git dep first.
           cargo update --package sia_storage_ffi
+          cargo update
           cargo fetch --target "$(rustc -vV | sed -n 's/^host: //p')"
           crate_version=$(cargo metadata --format-version 1 |
             jq -r '.packages[] | select(.name == "sia_storage_ffi") | .version')
@@ -164,9 +165,11 @@ jobs:
           set -euo pipefail
           title="chore: update sia_storage_ffi to $VERSION"
           if [[ "$VERIFY_OUTCOME" == success ]]; then
+            pr_title="$title"
             result="The Rust build and Swift binding generation passed."
           else
-            result="The Rust build or Swift binding generation failed; see the workflow logs."
+            pr_title="$title (build failed)"
+            result="**The Rust build or Swift binding generation failed; see the workflow logs.** The regenerated Swift bindings were therefore not copied into \`swift/Sources\`, so they are stale relative to the new revision. Opened as a draft — do not merge until the build is green."
           fi
           body=$(cat <<EOF
           Automated update to [\`$TAG\`](https://github.com/$UPSTREAM_REPO/releases/tag/$TAG) (\`$REV\`).
@@ -184,8 +187,21 @@ jobs:
           git push --force-with-lease origin "$BRANCH"
 
           if [[ -n "$PR" ]]; then
-            gh pr edit "$PR" --title "$title" --body "$body"
+            gh pr edit "$PR" --title "$pr_title" --body "$body"
+            if [[ "$VERIFY_OUTCOME" == success ]]; then
+              gh pr ready "$PR"
+            else
+              gh pr ready --undo "$PR"
+            fi
           else
+            draft=()
+            [[ "$VERIFY_OUTCOME" == success ]] || draft=(--draft)
             gh pr create --base "${{ github.event.repository.default_branch }}" \
-              --head "$BRANCH" --title "$title" --body "$body"
+              --head "$BRANCH" --title "$pr_title" --body "$body" "${draft[@]}"
           fi
+
+      - name: Fail if verification failed
+        if: steps.update.outputs.changed == 'true' && steps.verify.outcome != 'success'
+        run: |
+          echo "::error::cargo build or Swift binding generation failed; the pull request was opened as a draft."
+          exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.0",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -201,15 +201,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -338,12 +329,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64727038c8c5e2bb503a15b9f5b9df50a1da9a33e83e1f93067d914f2c6604a5"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.11.0",
- "crypto-common 0.2.0",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -456,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
@@ -563,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "crypto-common 0.2.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2143,7 +2134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2573,7 +2564,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.0",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,12 +4,12 @@ version = 4
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.0",
+ "inout",
 ]
 
 [[package]]
@@ -72,7 +72,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -102,13 +102,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -130,10 +130,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
+name = "base64"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "basic-toml"
@@ -176,7 +176,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -209,6 +209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,9 +240,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
@@ -291,45 +300,33 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cipher 0.5.0",
- "cpufeatures 0.3.0",
+ "cipher",
+ "cpufeatures",
  "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
- "chacha20 0.9.1",
- "cipher 0.4.4",
+ "chacha20",
+ "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -341,24 +338,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout 0.1.4",
- "zeroize",
-]
-
-[[package]]
-name = "cipher"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64727038c8c5e2bb503a15b9f5b9df50a1da9a33e83e1f93067d914f2c6604a5"
 dependencies = [
  "block-buffer 0.11.0",
  "crypto-common 0.2.0",
- "inout 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -391,7 +377,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -401,10 +387,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "constant_time_eq"
@@ -417,15 +403,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -474,7 +451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -484,19 +460,30 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -511,7 +498,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -534,7 +521,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -545,17 +532,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -580,6 +557,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,7 +574,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -598,24 +585,21 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
- "serde",
  "sha2",
  "subtle",
  "zeroize",
@@ -649,7 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -660,9 +644,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -729,7 +713,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -903,7 +887,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -999,7 +983,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1179,32 +1163,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1325,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1394,12 +1357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,16 +1375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,12 +1382,11 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -1475,7 +1421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1575,11 +1521,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -1592,15 +1538,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1655,7 +1592,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1664,7 +1601,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1738,7 +1675,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1829,7 +1766,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1844,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1854,22 +1791,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1912,7 +1849,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -1935,18 +1872,18 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1957,10 +1894,10 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sia_core"
-version = "0.4.1"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=720597d5b6f485851a54a1081f9ac614c601a4f9#720597d5b6f485851a54a1081f9ac614c601a4f9"
+version = "0.4.2"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=3947162955f6d665caa6a803bbe1f1484d7a0ca3#3947162955f6d665caa6a803bbe1f1484d7a0ca3"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "bip39",
  "blake2",
  "blake2b_simd",
@@ -1973,7 +1910,6 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "sha2",
  "sia_core_derive",
  "thiserror",
  "tokio",
@@ -1984,22 +1920,21 @@ dependencies = [
 [[package]]
 name = "sia_core_derive"
 version = "0.1.2"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=720597d5b6f485851a54a1081f9ac614c601a4f9#720597d5b6f485851a54a1081f9ac614c601a4f9"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=3947162955f6d665caa6a803bbe1f1484d7a0ca3#3947162955f6d665caa6a803bbe1f1484d7a0ca3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "sia_mux"
-version = "0.1.1"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=720597d5b6f485851a54a1081f9ac614c601a4f9#720597d5b6f485851a54a1081f9ac614c601a4f9"
+version = "0.1.2"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=3947162955f6d665caa6a803bbe1f1484d7a0ca3#3947162955f6d665caa6a803bbe1f1484d7a0ca3"
 dependencies = [
  "blake2b_simd",
  "bytes",
  "ed25519-dalek",
- "rand_core 0.6.4",
  "ring",
  "thiserror",
  "tokio",
@@ -2020,25 +1955,23 @@ dependencies = [
 
 [[package]]
 name = "sia_storage"
-version = "0.10.0"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=720597d5b6f485851a54a1081f9ac614c601a4f9#720597d5b6f485851a54a1081f9ac614c601a4f9"
+version = "0.11.0"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=3947162955f6d665caa6a803bbe1f1484d7a0ca3#3947162955f6d665caa6a803bbe1f1484d7a0ca3"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "blake2",
  "blake2b_simd",
  "bytes",
- "chacha20 0.10.0",
+ "chacha20",
  "chacha20poly1305",
  "chrono",
  "ed25519-dalek",
- "getrandom 0.2.17",
  "getrandom 0.4.2",
  "hex",
  "hkdf",
- "instant",
  "js-sys",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -2060,12 +1993,12 @@ dependencies = [
 
 [[package]]
 name = "sia_storage_ffi"
-version = "0.9.0"
-source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=720597d5b6f485851a54a1081f9ac614c601a4f9#720597d5b6f485851a54a1081f9ac614c601a4f9"
+version = "0.10.0"
+source = "git+https://github.com/SiaFoundation/sia-sdk-rs.git?rev=3947162955f6d665caa6a803bbe1f1484d7a0ca3#3947162955f6d665caa6a803bbe1f1484d7a0ca3"
 dependencies = [
  "async-trait",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sia_core",
  "sia_storage",
  "thiserror",
@@ -2077,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "sia_storage_sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "sia_storage_ffi",
  "uniffi",
@@ -2085,12 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "siphasher"
@@ -2123,17 +2053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2172,6 +2092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,7 +2119,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2212,10 +2143,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2229,22 +2160,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2326,7 +2257,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2341,14 +2272,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -2578,7 +2510,7 @@ dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2593,7 +2525,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.116",
  "toml",
  "uniffi_meta",
 ]
@@ -2637,12 +2569,12 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.0",
+ "ctutils",
 ]
 
 [[package]]
@@ -2755,7 +2687,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
  "wasm-bindgen-shared",
 ]
 
@@ -2915,7 +2847,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2926,7 +2858,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3167,7 +3099,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.116",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3183,7 +3115,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3233,13 +3165,13 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
  "zeroize",
 ]
 
@@ -3262,7 +3194,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
  "synstructure",
 ]
 
@@ -3283,7 +3215,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3303,28 +3235,28 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3357,7 +3289,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.116",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sia_storage_sdk"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 repository = "https://github.com/SiaFoundation/sia-storage-sdk"
 license = "MIT"
@@ -12,7 +12,7 @@ name = "sia_storage_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-sia_storage_ffi = { git = "https://github.com/SiaFoundation/sia-sdk-rs.git", rev = "720597d5b6f485851a54a1081f9ac614c601a4f9" }
+sia_storage_ffi = { git = "https://github.com/SiaFoundation/sia-sdk-rs.git", rev = "3947162955f6d665caa6a803bbe1f1484d7a0ca3" }
 uniffi = { version = "=0.31.1", features = ["cli", "tokio"] }
 
 [[bin]]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let binaryTarget: Target = useLocalBinary
     )
     : .binaryTarget(
         name: "SiaStorageSDKFFI",
-        url: "https://github.com/SiaFoundation/sia-storage-sdk/releases/download/v0.9.0/SiaStorageSDKFFI-0.9.0.xcframework.zip",
+        url: "https://github.com/SiaFoundation/sia-storage-sdk/releases/download/v0.10.0/SiaStorageSDKFFI-0.10.0.xcframework.zip",
         checksum: "ae2e6c6d35104aeb5e85b71ad86e842573d3f880594a45b4327c8ea6414291bb"
     )
 

--- a/SiaStorageSDK.podspec
+++ b/SiaStorageSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SiaStorageSDK'
-  s.version          = '0.9.0'
+  s.version          = '0.10.0'
   s.summary          = 'Swift SDK for Sia Storage'
   s.description      = <<-DESC
     SiaStorageSDK provides Swift bindings for interacting with Sia Storage.

--- a/examples/kotlin/README.md
+++ b/examples/kotlin/README.md
@@ -8,7 +8,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("tech.sia:siastoragesdk:0.9.0")
+    implementation("tech.sia:siastoragesdk:0.10.0")
 }
 ```
 

--- a/examples/kotlin/gradle.properties
+++ b/examples/kotlin/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.0
+version=0.10.0

--- a/examples/kotlin/src/main/kotlin/Example.kt
+++ b/examples/kotlin/src/main/kotlin/Example.kt
@@ -73,7 +73,7 @@ fun main() = runBlocking {
     println("\nUpload Packing Example...")
 
     start = System.currentTimeMillis()
-    val upload = sdk.uploadPacked(UploadOptions())
+    val upload = sdk.uploadPacked(PackedUploadOptions())
 
     for (i in 0 until 10) {
         val payload = "hello, world $i!"

--- a/examples/python/example.py
+++ b/examples/python/example.py
@@ -10,6 +10,7 @@ from sia_storage import (
     Builder,
     PinnedObject,
     UploadOptions,
+    PackedUploadOptions,
     DownloadOptions,
     set_logger,
     Logger,
@@ -99,7 +100,7 @@ async def main():
     print("\nUpload Packing Example...")
 
     start = datetime.now(timezone.utc)
-    upload = await sdk.upload_packed(UploadOptions())
+    upload = await sdk.upload_packed(PackedUploadOptions())
 
     for i in range(10):
         data = f"hello, world {i}!"

--- a/examples/swift/Sources/main.swift
+++ b/examples/swift/Sources/main.swift
@@ -96,7 +96,7 @@ struct SiaStorageSDKExample {
 
             // Packed upload example
             start = Date()
-            let upload = try await sdk.uploadPacked(options: UploadOptions())
+            let upload = try await sdk.uploadPacked(options: PackedUploadOptions())
 
             for i in 0..<10 {
                 let size = try await upload.add(data: "hello, world \(i)!".data(using: .utf8)!)

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -15,7 +15,7 @@ Add to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("tech.sia:siastoragesdk:0.9.0")
+    implementation("tech.sia:siastoragesdk:0.10.0")
 }
 ```
 

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 group=tech.sia
-version=0.9.0
+version=0.10.0

--- a/kotlin/src/main/kotlin/sia/indexd/Wrappers.kt
+++ b/kotlin/src/main/kotlin/sia/indexd/Wrappers.kt
@@ -10,6 +10,7 @@ package sia.indexd
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import kotlinx.coroutines.flow.Flow
@@ -87,6 +88,23 @@ suspend fun Sdk.upload(
     data: ByteArray,
     options: UploadOptions = UploadOptions(),
 ): PinnedObject = upload(obj, BytesReader(ByteArrayInputStream(data)), options)
+
+/**
+ * Upload a [File] to the Sia network.
+ *
+ * Prefer this to [upload] for files: the read stays on the runtime instead of
+ * crossing the FFI boundary once per chunk.
+ *
+ * Example:
+ * ```kotlin
+ * val obj = sdk.uploadPath(PinnedObject(), File("data.bin"))
+ * ```
+ */
+suspend fun Sdk.uploadPath(
+    obj: PinnedObject,
+    file: File,
+    options: UploadOptions = UploadOptions(),
+): PinnedObject = uploadPath(obj, file.path, options)
 
 /**
  * Reads the entire remaining stream into memory and returns it.
@@ -169,3 +187,18 @@ suspend fun PackedUpload.add(
 suspend fun PackedUpload.add(
     data: ByteArray,
 ): ULong = add(BytesReader(ByteArrayInputStream(data)))
+
+/**
+ * Add a [File] to a packed upload.
+ *
+ * Prefer this to [add] for files: the read stays on the runtime instead of
+ * crossing the FFI boundary once per chunk.
+ *
+ * Example:
+ * ```kotlin
+ * val size = upload.addPath(File("data.bin"))
+ * ```
+ */
+suspend fun PackedUpload.addPath(
+    file: File,
+): ULong = addPath(file.path)

--- a/python/sia_storage/__init__.py
+++ b/python/sia_storage/__init__.py
@@ -23,6 +23,7 @@ from sia_storage.sia_storage.sia_storage_ffi import (
     ShardProgress,
     Slab,
     UploadOptions,
+    PackedUploadOptions,
     DownloadOptions,
     # Enums
     AddressProtocol,
@@ -84,6 +85,7 @@ __all__ = [
     "ShardProgress",
     "Slab",
     "UploadOptions",
+    "PackedUploadOptions",
     "DownloadOptions",
     # Enums
     "AddressProtocol",

--- a/python/sia_storage/wrappers.py
+++ b/python/sia_storage/wrappers.py
@@ -19,6 +19,7 @@ from .sia_storage.sia_storage_ffi import (
     Download as _Download,
     DownloadOptions,
     PackedUpload as _PackedUpload,
+    PackedUploadOptions,
     PinnedObject,
     ProgressCallback,
     Reader,
@@ -55,6 +56,15 @@ def _wrap_progress(cb):
 def _prepare_upload_options(options: Optional[UploadOptions]) -> UploadOptions:
     if options is None:
         return UploadOptions()
+    options.shard_uploaded = _wrap_progress(options.shard_uploaded)
+    return options
+
+
+def _prepare_packed_upload_options(
+    options: Optional[PackedUploadOptions],
+) -> PackedUploadOptions:
+    if options is None:
+        return PackedUploadOptions()
     options.shard_uploaded = _wrap_progress(options.shard_uploaded)
     return options
 
@@ -155,7 +165,9 @@ class Sdk(_Sdk):
             _prepare_upload_options(options),
         )
 
-    async def upload_packed(self, options: Optional[UploadOptions] = None) -> PackedUpload:
+    async def upload_packed(
+        self, options: Optional[PackedUploadOptions] = None
+    ) -> PackedUpload:
         """Creates a new packed upload.
 
         This allows multiple objects to be packed together for more efficient
@@ -170,7 +182,7 @@ class Sdk(_Sdk):
             A PackedUpload that can be used to add objects and finalize the upload.
         """
         return PackedUpload._from_ffi(
-            await super().upload_packed(_prepare_upload_options(options))
+            await super().upload_packed(_prepare_packed_upload_options(options))
         )
 
     def download(self, obj: PinnedObject, options: Optional[DownloadOptions] = None) -> Download:

--- a/python/sia_storage/wrappers.py
+++ b/python/sia_storage/wrappers.py
@@ -9,6 +9,7 @@ plain-callable progress callbacks.
 from __future__ import annotations
 
 import asyncio
+import os
 from io import BytesIO
 from typing import Any, BinaryIO, Callable, Optional, Union
 
@@ -31,6 +32,8 @@ from .sia_storage.sia_storage_ffi import (
 
 
 ProgressHandler = Union[ProgressCallback, Callable[[ShardProgress], Any]]
+
+StrPath = Union[str, os.PathLike]
 
 
 class _CallableProgress(ProgressCallback):
@@ -162,6 +165,34 @@ class Sdk(_Sdk):
         return await super().upload(
             obj,
             BytesReader(r),
+            _prepare_upload_options(options),
+        )
+
+    async def upload_path(
+        self,
+        obj: PinnedObject,
+        path: StrPath,
+        options: Optional[UploadOptions] = None,
+    ) -> PinnedObject:
+        """Uploads the file at `path`. Behaves like upload() otherwise.
+
+        Prefer this to upload() for files: the read stays on the runtime
+        instead of crossing the FFI boundary once per chunk.
+
+        Args:
+            obj: The object to upload into. Use `PinnedObject()` for a new upload.
+            path: The file to upload. Accepts a `str` or any `os.PathLike`
+                (such as `pathlib.Path`).
+            options: The upload options. `shard_uploaded` accepts either a
+                ProgressCallback or any callable taking a ShardProgress.
+
+        Returns:
+            An object containing all slabs from `obj` plus the newly uploaded
+            slabs. The caller is responsible for pinning the returned object.
+        """
+        return await super().upload_path(
+            obj,
+            os.fspath(path),
             _prepare_upload_options(options),
         )
 
@@ -312,6 +343,21 @@ class PackedUpload(_PackedUpload):
         if isinstance(reader, (bytes, bytearray, memoryview)):
             reader = BytesIO(bytes(reader))
         return await super().add(BytesReader(reader))
+
+    async def add_path(self, path: StrPath) -> int:
+        """Adds the file at `path` to the upload.
+
+        Prefer this to add() for files: the read stays on the runtime instead
+        of crossing the FFI boundary once per chunk.
+
+        Args:
+            path: The file to add. Accepts a `str` or any `os.PathLike`
+                (such as `pathlib.Path`).
+
+        Returns:
+            The number of bytes read.
+        """
+        return await super().add_path(os.fspath(path))
 
 
 class BytesReader(Reader):

--- a/swift/README.md
+++ b/swift/README.md
@@ -16,7 +16,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/SiaFoundation/sia-storage-sdk", from: "0.9.0")
+    .package(url: "https://github.com/SiaFoundation/sia-storage-sdk", from: "0.10.0")
 ]
 ```
 
@@ -36,7 +36,7 @@ Or in Xcode: File → Add Packages → enter the repository URL.
 ### CocoaPods
 
 ```ruby
-pod 'SiaStorageSDK', '~> 0.9.0'
+pod 'SiaStorageSDK', '~> 0.10.0'
 ```
 
 ## Example

--- a/swift/Sources/SiaStorageSDK/SiaStorageSDK.swift
+++ b/swift/Sources/SiaStorageSDK/SiaStorageSDK.swift
@@ -1604,9 +1604,20 @@ public protocol PackedUploadProtocol: AnyObject, Sendable {
      *
      * If the reader errors part-way, it's safe to continue calling
      * [add](Self::add); no object is registered for the failed call. Or call
-     * [finalize](Self::finalize) to collect the objects added so far.
+     * [finalize](Self::finalize) to collect the objects added so far. Bytes
+     * read before the error remain in the current slab as padding and stay
+     * counted in [length](Self::length) and [remaining](Self::remaining).
      */
     func add(reader: Reader) async throws  -> UInt64
+    
+    /**
+     * Adds a new object to the upload by opening the file at `path`. Behaves
+     * like [add](Self::add) otherwise.
+     *
+     * Prefer this to [add](Self::add) for files: the read stays on the runtime
+     * instead of crossing the FFI boundary once per chunk.
+     */
+    func addPath(path: String) async throws  -> UInt64
     
     /**
      * Cancels the upload. This will immediately cancel any in-progress [add](Self::add) or [finalize](Self::finalize) operations and prevent
@@ -1707,7 +1718,9 @@ open class PackedUpload: PackedUploadProtocol, @unchecked Sendable {
      *
      * If the reader errors part-way, it's safe to continue calling
      * [add](Self::add); no object is registered for the failed call. Or call
-     * [finalize](Self::finalize) to collect the objects added so far.
+     * [finalize](Self::finalize) to collect the objects added so far. Bytes
+     * read before the error remain in the current slab as padding and stay
+     * counted in [length](Self::length) and [remaining](Self::remaining).
      */
 open func add(reader: Reader)async throws  -> UInt64  {
     return
@@ -1716,6 +1729,30 @@ open func add(reader: Reader)async throws  -> UInt64  {
                 uniffi_sia_storage_ffi_fn_method_packedupload_add(
                     self.uniffiCloneHandle(),
                     FfiConverterTypeReader_lower(reader)
+                )
+            },
+            pollFunc: ffi_sia_storage_ffi_rust_future_poll_u64,
+            completeFunc: ffi_sia_storage_ffi_rust_future_complete_u64,
+            freeFunc: ffi_sia_storage_ffi_rust_future_free_u64,
+            liftFunc: FfiConverterUInt64.lift,
+            errorHandler: FfiConverterTypeUploadError_lift
+        )
+}
+    
+    /**
+     * Adds a new object to the upload by opening the file at `path`. Behaves
+     * like [add](Self::add) otherwise.
+     *
+     * Prefer this to [add](Self::add) for files: the read stays on the runtime
+     * instead of crossing the FFI boundary once per chunk.
+     */
+open func addPath(path: String)async throws  -> UInt64  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_sia_storage_ffi_fn_method_packedupload_add_path(
+                    self.uniffiCloneHandle(),
+                    FfiConverterString.lower(path)
                 )
             },
             pollFunc: ffi_sia_storage_ffi_rust_future_poll_u64,
@@ -2702,12 +2739,30 @@ public protocol SdkProtocol: AnyObject, Sendable {
      * for more efficient uploads. The returned `PackedUpload` can be used to add objects to the upload, and then finalized to get the resulting objects.
      *
      * # Arguments
-     * * `options` - The [UploadOptions] to use for the upload.
+     * * `options` - The [PackedUploadOptions] to use for the upload.
      *
      * # Returns
      * A [PackedUpload] that can be used to add objects and finalize the upload.
      */
-    func uploadPacked(options: UploadOptions) async throws  -> PackedUpload
+    func uploadPacked(options: PackedUploadOptions) async throws  -> PackedUpload
+    
+    /**
+     * Uploads the file at `path`. Behaves like [upload](Self::upload)
+     * otherwise.
+     *
+     * Prefer this to [upload](Self::upload) for files: the read stays on the
+     * runtime instead of crossing the FFI boundary once per chunk.
+     *
+     * # Arguments
+     * * `object` - The object to upload into. Use [PinnedObject::new] for new uploads.
+     * * `path` - The path of the file to upload.
+     * * `options` - The [UploadOptions] to use for the upload.
+     *
+     * # Returns
+     * A new object containing all slabs from the input object plus the newly
+     * uploaded slabs. The caller must pin the object to the indexer afterward.
+     */
+    func uploadPath(object: PinnedObject, path: String, options: UploadOptions) async throws  -> PinnedObject
     
 }
 open class Sdk: SdkProtocol, @unchecked Sendable {
@@ -3052,24 +3107,57 @@ open func upload(object: PinnedObject, r: Reader, options: UploadOptions)async t
      * for more efficient uploads. The returned `PackedUpload` can be used to add objects to the upload, and then finalized to get the resulting objects.
      *
      * # Arguments
-     * * `options` - The [UploadOptions] to use for the upload.
+     * * `options` - The [PackedUploadOptions] to use for the upload.
      *
      * # Returns
      * A [PackedUpload] that can be used to add objects and finalize the upload.
      */
-open func uploadPacked(options: UploadOptions)async throws  -> PackedUpload  {
+open func uploadPacked(options: PackedUploadOptions)async throws  -> PackedUpload  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_sia_storage_ffi_fn_method_sdk_upload_packed(
                     self.uniffiCloneHandle(),
-                    FfiConverterTypeUploadOptions_lower(options)
+                    FfiConverterTypePackedUploadOptions_lower(options)
                 )
             },
             pollFunc: ffi_sia_storage_ffi_rust_future_poll_u64,
             completeFunc: ffi_sia_storage_ffi_rust_future_complete_u64,
             freeFunc: ffi_sia_storage_ffi_rust_future_free_u64,
             liftFunc: FfiConverterTypePackedUpload_lift,
+            errorHandler: FfiConverterTypeUploadError_lift
+        )
+}
+    
+    /**
+     * Uploads the file at `path`. Behaves like [upload](Self::upload)
+     * otherwise.
+     *
+     * Prefer this to [upload](Self::upload) for files: the read stays on the
+     * runtime instead of crossing the FFI boundary once per chunk.
+     *
+     * # Arguments
+     * * `object` - The object to upload into. Use [PinnedObject::new] for new uploads.
+     * * `path` - The path of the file to upload.
+     * * `options` - The [UploadOptions] to use for the upload.
+     *
+     * # Returns
+     * A new object containing all slabs from the input object plus the newly
+     * uploaded slabs. The caller must pin the object to the indexer afterward.
+     */
+open func uploadPath(object: PinnedObject, path: String, options: UploadOptions)async throws  -> PinnedObject  {
+    return
+        try  await uniffiRustCallAsync(
+            rustFutureFunc: {
+                uniffi_sia_storage_ffi_fn_method_sdk_upload_path(
+                    self.uniffiCloneHandle(),
+                    FfiConverterTypePinnedObject_lower(object),FfiConverterString.lower(path),FfiConverterTypeUploadOptions_lower(options)
+                )
+            },
+            pollFunc: ffi_sia_storage_ffi_rust_future_poll_u64,
+            completeFunc: ffi_sia_storage_ffi_rust_future_complete_u64,
+            freeFunc: ffi_sia_storage_ffi_rust_future_free_u64,
+            liftFunc: FfiConverterTypePinnedObject_lift,
             errorHandler: FfiConverterTypeUploadError_lift
         )
 }
@@ -3707,6 +3795,77 @@ public func FfiConverterTypeObjectsCursor_lower(_ value: ObjectsCursor) -> RustB
 
 
 /**
+ * Provides options for a packed upload operation.
+ */
+public struct PackedUploadOptions {
+    public var maxBufferedSlabs: UInt32?
+    public var dataShards: UInt8?
+    public var parityShards: UInt8?
+    /**
+     * Optional callback to report upload progress.
+     */
+    public var shardUploaded: ProgressCallback?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(maxBufferedSlabs: UInt32? = nil, dataShards: UInt8? = nil, parityShards: UInt8? = nil, 
+        /**
+         * Optional callback to report upload progress.
+         */shardUploaded: ProgressCallback? = nil) {
+        self.maxBufferedSlabs = maxBufferedSlabs
+        self.dataShards = dataShards
+        self.parityShards = parityShards
+        self.shardUploaded = shardUploaded
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension PackedUploadOptions: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypePackedUploadOptions: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PackedUploadOptions {
+        return
+            try PackedUploadOptions(
+                maxBufferedSlabs: FfiConverterOptionUInt32.read(from: &buf), 
+                dataShards: FfiConverterOptionUInt8.read(from: &buf), 
+                parityShards: FfiConverterOptionUInt8.read(from: &buf), 
+                shardUploaded: FfiConverterOptionTypeProgressCallback.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: PackedUploadOptions, into buf: inout [UInt8]) {
+        FfiConverterOptionUInt32.write(value.maxBufferedSlabs, into: &buf)
+        FfiConverterOptionUInt8.write(value.dataShards, into: &buf)
+        FfiConverterOptionUInt8.write(value.parityShards, into: &buf)
+        FfiConverterOptionTypeProgressCallback.write(value.shardUploaded, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePackedUploadOptions_lift(_ buf: RustBuffer) throws -> PackedUploadOptions {
+    return try FfiConverterTypePackedUploadOptions.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypePackedUploadOptions_lower(_ value: PackedUploadOptions) -> RustBuffer {
+    return FfiConverterTypePackedUploadOptions.lower(value)
+}
+
+
+/**
  * A sector stored on a specific host.
  */
 public struct PinnedSector: Equatable, Hashable {
@@ -3767,6 +3926,7 @@ public func FfiConverterTypePinnedSector_lower(_ value: PinnedSector) -> RustBuf
  * A PinnedSlab represents a slab that has been pinned to the indexer.
  */
 public struct PinnedSlab: Equatable, Hashable {
+    public var version: UInt8
     public var id: String
     public var encryptionKey: Data
     public var minShards: UInt8
@@ -3774,7 +3934,8 @@ public struct PinnedSlab: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: String, encryptionKey: Data, minShards: UInt8, sectors: [PinnedSector]) {
+    public init(version: UInt8, id: String, encryptionKey: Data, minShards: UInt8, sectors: [PinnedSector]) {
+        self.version = version
         self.id = id
         self.encryptionKey = encryptionKey
         self.minShards = minShards
@@ -3797,6 +3958,7 @@ public struct FfiConverterTypePinnedSlab: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> PinnedSlab {
         return
             try PinnedSlab(
+                version: FfiConverterUInt8.read(from: &buf), 
                 id: FfiConverterString.read(from: &buf), 
                 encryptionKey: FfiConverterData.read(from: &buf), 
                 minShards: FfiConverterUInt8.read(from: &buf), 
@@ -3805,6 +3967,7 @@ public struct FfiConverterTypePinnedSlab: FfiConverterRustBuffer {
     }
 
     public static func write(_ value: PinnedSlab, into buf: inout [UInt8]) {
+        FfiConverterUInt8.write(value.version, into: &buf)
         FfiConverterString.write(value.id, into: &buf)
         FfiConverterData.write(value.encryptionKey, into: &buf)
         FfiConverterUInt8.write(value.minShards, into: &buf)
@@ -3988,6 +4151,7 @@ public func FfiConverterTypeShardProgress_lower(_ value: ShardProgress) -> RustB
  * A Slab represents a contiguous erasure-coded segment of a file stored on the Sia network.
  */
 public struct Slab: Equatable, Hashable {
+    public var version: UInt8
     public var encryptionKey: Data
     public var minShards: UInt8
     public var sectors: [PinnedSector]
@@ -3996,7 +4160,8 @@ public struct Slab: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(encryptionKey: Data, minShards: UInt8, sectors: [PinnedSector], offset: UInt32, length: UInt32) {
+    public init(version: UInt8, encryptionKey: Data, minShards: UInt8, sectors: [PinnedSector], offset: UInt32, length: UInt32) {
+        self.version = version
         self.encryptionKey = encryptionKey
         self.minShards = minShards
         self.sectors = sectors
@@ -4020,6 +4185,7 @@ public struct FfiConverterTypeSlab: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Slab {
         return
             try Slab(
+                version: FfiConverterUInt8.read(from: &buf), 
                 encryptionKey: FfiConverterData.read(from: &buf), 
                 minShards: FfiConverterUInt8.read(from: &buf), 
                 sectors: FfiConverterSequenceTypePinnedSector.read(from: &buf), 
@@ -4029,6 +4195,7 @@ public struct FfiConverterTypeSlab: FfiConverterRustBuffer {
     }
 
     public static func write(_ value: Slab, into buf: inout [UInt8]) {
+        FfiConverterUInt8.write(value.version, into: &buf)
         FfiConverterData.write(value.encryptionKey, into: &buf)
         FfiConverterUInt8.write(value.minShards, into: &buf)
         FfiConverterSequenceTypePinnedSector.write(value.sectors, into: &buf)
@@ -4061,6 +4228,11 @@ public struct UploadOptions {
     public var dataShards: UInt8?
     public var parityShards: UInt8?
     /**
+     * When set, overwrites the object's existing data starting at this byte
+     * offset instead of appending.
+     */
+    public var startOffset: UInt64?
+    /**
      * Optional callback to report upload progress.
      */
     public var shardUploaded: ProgressCallback?
@@ -4069,11 +4241,16 @@ public struct UploadOptions {
     // declare one manually.
     public init(maxBufferedSlabs: UInt32? = nil, dataShards: UInt8? = nil, parityShards: UInt8? = nil, 
         /**
+         * When set, overwrites the object's existing data starting at this byte
+         * offset instead of appending.
+         */startOffset: UInt64? = nil, 
+        /**
          * Optional callback to report upload progress.
          */shardUploaded: ProgressCallback? = nil) {
         self.maxBufferedSlabs = maxBufferedSlabs
         self.dataShards = dataShards
         self.parityShards = parityShards
+        self.startOffset = startOffset
         self.shardUploaded = shardUploaded
     }
 
@@ -4096,6 +4273,7 @@ public struct FfiConverterTypeUploadOptions: FfiConverterRustBuffer {
                 maxBufferedSlabs: FfiConverterOptionUInt32.read(from: &buf), 
                 dataShards: FfiConverterOptionUInt8.read(from: &buf), 
                 parityShards: FfiConverterOptionUInt8.read(from: &buf), 
+                startOffset: FfiConverterOptionUInt64.read(from: &buf), 
                 shardUploaded: FfiConverterOptionTypeProgressCallback.read(from: &buf)
         )
     }
@@ -4104,6 +4282,7 @@ public struct FfiConverterTypeUploadOptions: FfiConverterRustBuffer {
         FfiConverterOptionUInt32.write(value.maxBufferedSlabs, into: &buf)
         FfiConverterOptionUInt8.write(value.dataShards, into: &buf)
         FfiConverterOptionUInt8.write(value.parityShards, into: &buf)
+        FfiConverterOptionUInt64.write(value.startOffset, into: &buf)
         FfiConverterOptionTypeProgressCallback.write(value.shardUploaded, into: &buf)
     }
 }
@@ -5572,7 +5751,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_sia_storage_ffi_checksum_method_download_read() != 37314) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_sia_storage_ffi_checksum_method_packedupload_add() != 51351) {
+    if (uniffi_sia_storage_ffi_checksum_method_packedupload_add() != 50710) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_sia_storage_ffi_checksum_method_packedupload_add_path() != 54420) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_sia_storage_ffi_checksum_method_packedupload_cancel() != 64519) {
@@ -5662,7 +5844,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_sia_storage_ffi_checksum_method_sdk_upload() != 27415) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_sia_storage_ffi_checksum_method_sdk_upload_packed() != 37714) {
+    if (uniffi_sia_storage_ffi_checksum_method_sdk_upload_packed() != 6247) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_sia_storage_ffi_checksum_method_sdk_upload_path() != 16130) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_sia_storage_ffi_checksum_method_appkey_export() != 16630) {

--- a/swift/Sources/SiaStorageSDK/Wrappers.swift
+++ b/swift/Sources/SiaStorageSDK/Wrappers.swift
@@ -140,6 +140,25 @@ extension Sdk {
     ) async throws -> PinnedObject {
         return try await upload(object: object, r: BytesReader(stream: stream), options: options)
     }
+
+    /**
+     * Upload the file at a local `URL` to the Sia network.
+     *
+     * Prefer this to `upload` for files: the read stays on the runtime instead
+     * of crossing the FFI boundary once per chunk.
+     *
+     * Example:
+     * ```swift
+     * let obj = try await sdk.uploadPath(object: PinnedObject(), url: URL(fileURLWithPath: "data.bin"))
+     * ```
+     */
+    public func uploadPath(
+        object: PinnedObject,
+        url: URL,
+        options: UploadOptions = UploadOptions()
+    ) async throws -> PinnedObject {
+        return try await uploadPath(object: object, path: url.path, options: options)
+    }
 }
 
 /**
@@ -242,5 +261,20 @@ extension PackedUpload {
 
     public func add(stream: InputStream) async throws -> UInt64 {
         return try await add(reader: BytesReader(stream: stream))
+    }
+
+    /**
+     * Add the file at a local `URL` to a packed upload.
+     *
+     * Prefer this to `add` for files: the read stays on the runtime instead of
+     * crossing the FFI boundary once per chunk.
+     *
+     * Example:
+     * ```swift
+     * let size = try await upload.addPath(url: URL(fileURLWithPath: "data.bin"))
+     * ```
+     */
+    public func addPath(url: URL) async throws -> UInt64 {
+        return try await addPath(path: url.path)
     }
 }


### PR DESCRIPTION
Automated update to [`sia_storage_ffi/v0.10.0`](https://github.com/SiaFoundation/sia-sdk-rs/releases/tag/sia_storage_ffi/v0.10.0) (`3947162955f6d665caa6a803bbe1f1484d7a0ca3`).

The Rust build or Swift binding generation failed; see the workflow logs.

Before merging, review the hand-written Kotlin, Swift, and Python wrappers. The `Package.swift` checksum remains unchanged until the new xcframework is published.